### PR TITLE
fix: non existing var in code during replace variable

### DIFF
--- a/JavaScript/__tests__/replaceVariables.json
+++ b/JavaScript/__tests__/replaceVariables.json
@@ -57,6 +57,13 @@
         "var1": "zed"
       },
       "result": "<pre><code>zed = \"x marks the spot\"</code></pre><pre><code>xy = 5 + zed</code></pre>"
+    },
+    {
+      "code": "<pre><code>b = \"x marks the spot\"</code></pre><pre><code>xy = 5 + x</code></pre>",
+      "variableChanges": {
+        "var1": "zed"
+      },
+      "result": "<pre><code>b = \"x marks the spot\"</code></pre><pre><code>xy = 5 + zed</code></pre>"
     }
   ]
 }

--- a/JavaScript/src/antlr4.interpreter.js
+++ b/JavaScript/src/antlr4.interpreter.js
@@ -91,11 +91,15 @@ export default class Interpreter {
       const targetVar = Object.values(this.varObjects).find(
         variable => variable.name === varToken.text
       );
-      varToken.id = targetVar.id;
+      if (targetVar?.id) {
+        varToken.id = targetVar.id;
+      }
     });
 
     const f = variableTokens
-      .filter(varToken => Object.keys(variables).includes(varToken.id))
+      .filter(varToken =>
+        varToken.id ? Object.keys(variables).includes(varToken.id) : false
+      )
       .sort((a, b) => b.start - a.start);
     let newCode = code;
     f.forEach(varToken => {


### PR DESCRIPTION
This PR fixes an issue during `replaceVariables` where an exception is thrown when the code has a variable that doesn't exist in the variable context.